### PR TITLE
Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Every other day shows the final result.
 The testing library is 'speclj'.  You'll see it referenced in project.clj.
 The java version is 1.8.  
 
-As requested by the AOC team, I'll be adding solutions a few days behind, just go keep things "fair". 
+As requested by the AOC team, I'll be adding solutions a few days behind, just to keep things "fair". 


### PR DESCRIPTION
`just go keep things fair` → `just to keep things fair`